### PR TITLE
Fixes #15 new report keeps previous reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,5 @@ deploy:
   target_branch: gh-pages
   keep-history: true
   on:
-    branch: master
+    all_branches: true
+    condition: $TRAVIS_BRANCH =~ ^master|feature\/report$

--- a/getPreviousReport.sh
+++ b/getPreviousReport.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
-PREVIOUS_DOCS=./previous_docs
-echo " * get previous report"
-rm -rf ${PREVIOUS_DOCS} || echo ""
-git clone https://github.com/geokrety/geokrety-website-qa.git --branch gh-pages --single-branch ${PREVIOUS_DOCS}
-rm -rf ${PREVIOUS_DOCS}/.git || echo "not a git repo"
+PUBLICATION_BRANCH=gh-pages
+REPO_PATH=$PWD
+echo " * get previous report (from $HOME)"
+# work from HOME
+pushd $HOME > /dev/null
+git clone --quiet --branch ${PUBLICATION_BRANCH} --single-branch \
+  https://github.com/geokrety/geokrety-website-qa.git publish 2>&1 >/dev/null
+pushd $HOME/publish > /dev/null
 echo " * imported previous reports:"
-ls -d ${PREVIOUS_DOCS}/*/ || echo "nothing to import"
-# get copy of latest reports
-cp -rf ${PREVIOUS_DOCS}/boly38 docs/ 2>/dev/null || echo "no previous docs for boly38"
-cp -rf ${PREVIOUS_DOCS}/master docs/ 2>/dev/null || echo "no previous docs for master"
+ls -lad ./*/ | awk '{print $5, $6, $7, $8, $9}'
+cp -r ./*/ "${REPO_PATH}/docs/"
+popd > /dev/null
+popd > /dev/null

--- a/runTests.sh
+++ b/runTests.sh
@@ -55,4 +55,11 @@ fi
 #
 echo " * Execute robot framework tests |>>${ENV}<<<| targetUrl=${ENV_URL} buildDir=${BUILD_DIR}"
 ENV_VARS_FILE="-V acceptance/vars/robot-vars.py"
-${PYBOT} -d ${BUILD_DIR} ${ENV_VARS_FILE} acceptance/TestGeoKrety/
+${PYBOT} -d ${BUILD_DIR} ${ENV_VARS_FILE} acceptance/TestGeoKrety/GK_welcome.robot
+PYBOT_RESULT=$?
+if [ "${PYBOT_RESULT}" == "0" ]; then
+  echo "tests SUCCESS";
+else
+  echo "tests FAILED";
+fi
+echo "${PYBOT_RESULT}">${BUILD_DIR}/EXIT_CODE


### PR DESCRIPTION
related to #15 :

- fix `getPreviousReport.sh`
- travis must deploy master or feature/report
- travis must not stop if robot tests are failing
- test exit code available in dedicated file