### PR TITLE
add Page WithoutWarningOrFailure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,30 @@
 language: python
 python:
-  - 2.7.15
+- 2.7.15
 dist: trusty
 env:
-# QA Tests target environments: allowed value are 'boly38' or 'master'
-  - TARGET_ENV=master
+# QA Tests
+# https://docs.travis-ci.com/user/environment-variables/#defining-multiple-variables-per-item
+# TARGET_ENV: allowed value are 'boly38' or 'master' (default)
+# TARGET_TEST: empty means execute all tests(default), or set robot filename to execute single test
+- TARGET_ENV=master TARGET_TEST=
 sudo: required
 addons:
   chrome: stable
   firefox: latest
 install:
-  - pip install --upgrade pip
-  - pip -V
-  - pip install -r requirements.txt
+- pip install --upgrade pip
+- pip -V
+- pip install -r requirements.txt
 before_script:
 #  - wget --quiet "http://chromedriver.storage.googleapis.com/2.43/chromedriver_linux64.zip"
 #  - unzip chromedriver_linux64.zip
 #  - sudo mv chromedriver /usr/local/bin
 #  - ./scripts/makeChromeDriverVerbose.sh
-  - wget --quiet "https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz"
-  - tar -xzvf geckodriver-v0.23.0-linux64.tar.gz
-  - sudo mv geckodriver /usr/local/bin
-  - touch ./scripts/.requirements_checked
+- wget --quiet "https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz"
+- tar -xzvf geckodriver-v0.23.0-linux64.tar.gz
+- sudo mv geckodriver /usr/local/bin
+- touch ./scripts/.requirements_checked
 jobs:
   include:
   - stage: qaTests
@@ -31,9 +34,9 @@ jobs:
 
 notifications:
   irc:
-      channels:
-          - "chat.freenode.net#geokrety"
-      on_success: always
-      on_failure: always
-      template:
-          - "%{build_url} QA %{build_number} | %{branch} | %{commit_subject} | %{result}"
+    channels:
+    - "chat.freenode.net#geokrety"
+    on_success: always
+    on_failure: always
+    template:
+    - "%{build_url} QA %{build_number} | %{branch} | %{commit_subject} | %{result}"

--- a/acceptance/TestGeoKrety/00_GK_welcome.robot
+++ b/acceptance/TestGeoKrety/00_GK_welcome.robot
@@ -12,6 +12,7 @@ Welcome: (EN)
   !Go To GeoKrety
   !Click On EN Flag
   Page WaitForPage
+  Page WithoutWarningOrFailure
   Welcome ShouldShow Geokrety
   Welcome ShouldShow News
   Welcome ShouldShow RecentLogs
@@ -25,6 +26,7 @@ Welcome: (FR)
   !Go To GeoKrety
   !Click On FR Flag
   Page WaitForPage
+  Page WithoutWarningOrFailure
   Welcome ShouldShow GeokretyFR
   Welcome ShouldShow NewsFR
   Welcome ShouldShow RecentLogsFR
@@ -35,6 +37,8 @@ Welcome: input geokret code
   [Tags]             RUCHY
   !Go To GeoKrety
   !Click On EN Flag
+  Page WaitForPage
+  Page WithoutWarningOrFailure
   !Enter TrackingCode  ${TEST_GEOKRET_CODE}
   !Click On FoundGeokretGo
   Location Should Be   ${GK_URL_RUCHY}?nr=${TEST_GEOKRET_CODE}

--- a/acceptance/TestGeoKrety/01_GK_ruchy.robot
+++ b/acceptance/TestGeoKrety/01_GK_ruchy.robot
@@ -12,6 +12,7 @@ Ruchy: (EN)
   [Tags]             EN
   !Go To Ruchy
   Page WaitForPage
+  Page WithoutWarningOrFailure
   Ruchy ShouldShow LogType
   Ruchy ShouldShow IdentifyGeokret
   Ruchy ShouldShow NewLocation
@@ -23,6 +24,7 @@ Ruchy: search waypoint by GC code
   [Tags]             EN  search  waypoint
   !Go To Ruchy
   Page WaitForPage
+  Page WithoutWarningOrFailure
   Ruchy 3Waypoint Enter     GC1AQ2N
   Ruchy 3Waypoint ShouldBe  GC1AQ2N
   Ruchy 3Context WaitOKResult
@@ -35,6 +37,7 @@ Ruchy: search waypoint by name with more than 1 result
   [Tags]             EN  search  waypoint
   !Go To Ruchy
   Page WaitForPage
+  Page WithoutWarningOrFailure
   Ruchy 3Name Enter             voyage
   Ruchy ClickOn Check
 
@@ -55,6 +58,7 @@ Ruchy: search waypoint by name with exactly 1 result
   [Tags]             EN  search  waypoint
   !Go To Ruchy
   Page WaitForPage
+  Page WithoutWarningOrFailure
   Ruchy 3Name Enter         Bon Voyage Swampy
   Ruchy ClickOn Check
 
@@ -68,6 +72,7 @@ Ruchy: search waypoint by name with no result
   [Tags]             EN  search  waypoint
   !Go To Ruchy
   Page WaitForPage
+  Page WithoutWarningOrFailure
   Ruchy 3Name Enter         glogloglo
   Ruchy ClickOn Check
 
@@ -79,6 +84,7 @@ Ruchy: search waypoint by code with invalid prefix
   [Tags]             EN  search  waypoint
   !Go To Ruchy
   Page WaitForPage
+  Page WithoutWarningOrFailure
   Ruchy 3Waypoint Enter         XX_C100N_AHV
   Ruchy 3Waypoint ShouldBe      XX_C100N_AHV
   Ruchy 3Context WaitKOMissing
@@ -89,6 +95,7 @@ Ruchy: search waypoint by code with unknown GC
   [Tags]             EN  search  waypoint
   !Go To Ruchy
   Page WaitForPage
+  Page WithoutWarningOrFailure
   Ruchy 3Waypoint Enter         GC120999
   Ruchy 3Waypoint ShouldBe      GC120999
   Ruchy 3Context WaitKOMissing

--- a/acceptance/TestGeoKrety/02_GK_konkret.robot
+++ b/acceptance/TestGeoKrety/02_GK_konkret.robot
@@ -1,0 +1,17 @@
+*** Settings ***
+Library         SeleniumLibrary  timeout=10  implicit_wait=0
+Resource        ../functions/PageKonkret.robot
+Test Teardown   Close All Browsers
+Force Tags      Konkret
+Test Timeout    2 minutes
+
+*** Test Cases ***
+
+Konkret: (EN)
+  [Documentation]    default page
+  [Tags]             EN
+  !Go To Konkret
+  Page WaitForPage
+  Page WithoutWarningOrFailure
+  Konkret ShouldShow GeokretInfo
+  Page ShouldShow Footer

--- a/acceptance/functions/FunctionsGlobal.robot
+++ b/acceptance/functions/FunctionsGlobal.robot
@@ -50,6 +50,11 @@ Resource        travis_${TRAVIS_FLAG}/Xvbf.robot
 Page WaitForPage
   Wait Until Page Contains Element  ${ELT_TOP}
 
+Page WithoutWarningOrFailure
+  Page Should Not Contain  Warning:
+  Page Should Not Contain  Failed
+
+
 Page ShouldShow Footer
   Page Should Contain  Made in Poland
   Page Should Contain  by filips

--- a/acceptance/functions/PageKonkret.robot
+++ b/acceptance/functions/PageKonkret.robot
@@ -1,0 +1,17 @@
+*** Settings ***
+Resource        FunctionsGlobal.robot
+
+*** Keywords ***
+!Go To Konkret
+    !Go To GeoKrety
+    !Click On EN Flag
+    Go To             ${GK_URL}/konkret.php?id=60442
+
+Konkret ShouldShow GeokretInfo
+  Page Should Contain  Reference Number:
+  Page Should Contain  Total distance:
+  Page Should Contain  Places visited:
+  Page Should Contain  Forum links:
+  Page Should Contain  Country track:
+  Page Should Contain  Rating:
+  Page Should Contain  Share on:

--- a/scripts/runTests.sh
+++ b/scripts/runTests.sh
@@ -91,7 +91,7 @@ PYBOT_ARGS="${PYBOT_ARGS} -d ${BUILD_DIR} ${ENV_VARS_FILE}"
 echo " * Execute robot framework tests |>>${ENV}<<<| targetUrl=${ENV_URL}"
 echo "   PYBOT_ARGS:${PYBOT_ARGS}"
 
-${PYBOT} ${PYBOT_ARGS} acceptance/TestGeoKrety/
+${PYBOT} ${PYBOT_ARGS} acceptance/TestGeoKrety/${TARGET_TEST}
 
 PYBOT_RESULT=$?
 echo "${PYBOT_RESULT}">${BUILD_DIR}/EXIT_CODE


### PR DESCRIPTION
- add 'Page WithoutWarningOrFailure' to existing tests
- add Konkret Basis to test 'Page WithoutWarningOrFailure' (failed on boly38)
- fixes #41

bonus
- add a way to set TARGET_TEST as build env var (github wiki [IntelliJ page](https://github.com/geokrety/geokrety-website-qa/wiki/IntelliJ#run-tests)  updated)