### PR TITLE
Fixes #42 improve Ruchy tests time

### DIFF
--- a/acceptance/TestGeoKrety/01_GK_ruchy.robot
+++ b/acceptance/TestGeoKrety/01_GK_ruchy.robot
@@ -1,11 +1,12 @@
 *** Settings ***
 Library         SeleniumLibrary  timeout=10  implicit_wait=0
 Resource        ../functions/PageRuchy.robot
-Test Teardown   Close All Browsers
 Force Tags      Ruchy
 Test Timeout    2 minutes
 
 *** Test Cases ***
+Ruchy: start
+  !Open browser onto ruchy
 
 Ruchy: (EN)
   [Documentation]    default page
@@ -101,4 +102,7 @@ Ruchy: search waypoint by code with unknown GC
   Ruchy 3Context WaitKOMissing
   Ruchy 3Context ShouldInclude  Missing or invalid coordinates
   Ruchy 3Name Disabled
+
+Ruchy: end
+  Close All Browsers
 

--- a/acceptance/functions/PageRuchy.robot
+++ b/acceptance/functions/PageRuchy.robot
@@ -2,13 +2,16 @@
 Resource        FunctionsGlobal.robot
 
 *** Keywords ***
-!Go To Ruchy
+!Open browser onto ruchy
     !Go To GeoKrety
     !Click On EN Flag
     Wait Until Element Is Visible  ${LINK_LOG_A_GK}
     Wait Until Page Contains       Log a GeoKret
     Click Link                     ${LINK_LOG_A_GK}
     Location Should Be             ${GK_URL}ruchy.php
+
+!Go To Ruchy
+    Go To                          ${GK_URL}ruchy.php
 
 Ruchy ShouldShow LogType
   Page Should Contain  Choose log type


### PR DESCRIPTION
Fixes #42 improve Ruchy tests time

- only one "open browser" instruction for all ruchy related tests seems more adapted :+1: 