### PR TITLE
Fix #52 new-them qa compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,24 @@
 SHELL := /bin/bash
 CURRENT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+PTY_PREFIX=
+ifeq (Windows_NT, ${OS})
+	PTY_PREFIX=winpty
+endif
 
-all: clean build test
+# HELP
+# This will output the help for each task
+# thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+.PHONY: help
 
-clean:
-	@echo "Clean"
-	rm -rf .py27
+help: ## This help.
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-build:
-	@echo "Build"
-	virtualenv-2.7 .py27 || virtualenv .py27
-	.py27/bin/pip install -r requirements.txt
-
-test:
+test: ## run robot framework tests (master env)
 	@echo "Run Tests"
-	.py27/bin/pybot test.robot
+	./scripts/runTests.sh
+testlocal: ## run robot framework tests (local env)
+	@echo "Run Tests"
+	./scripts/runTests.sh local
+testv2: ## run robot framework tests (newtheme env)
+	@echo "Run Tests"
+	./scripts/runTests.sh newtheme

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Quality Assurance tests are executed against default configuration located in `a
 
 - clone me
 - install python+pip
-- just execute `./scripts/runTests.sh`
+- just execute `make help`
 
 # Contribute
 - [Wiki page](https://github.com/geokrety/geokrety-website-qa/wiki) includes good practices and tips,

--- a/acceptance/TestGeoKretyV2/00_GK_welcome.robot
+++ b/acceptance/TestGeoKretyV2/00_GK_welcome.robot
@@ -1,0 +1,19 @@
+*** Settings ***
+Library         SeleniumLibrary  timeout=10  implicit_wait=0
+Resource        ../functions/PageWelcome.robot
+Test Teardown   Close All Browsers
+Force Tags      Welcome
+Test Timeout    2 minutes
+
+*** Test Cases ***
+Welcome: (EN)
+  [Documentation]    Default english welcome page
+  [Tags]             EN
+  !Go To GeoKrety
+  !Click On EN Lang
+
+Welcome: (FR)
+  [Documentation]    Welcome page in french
+  [Tags]             FR
+  !Go To GeoKrety
+  !Click On FR Lang

--- a/acceptance/functions/ComponentsLocator.robot
+++ b/acceptance/functions/ComponentsLocator.robot
@@ -44,3 +44,10 @@ ${BTN_RUCHY_TIME_NOW}        xpath=//*[@id="prawo"]/form/div[6]/div[3]/div/butto
 ${ELT_RUCHY_COMMENT}         id=poledoliczenia
 
 ${BTN_RUCHY_GO}              xpath=//*[@id="prawo"]/form/div[8]/div/input[1]
+
+################
+#   COMMON V2
+################
+${DROPDOWN_LANG}     id=navbar-lang
+${DROPDOWN_LANG_EN}  id=navbar-lang-en
+${DROPDOWN_LANG_FR}  id=navbar-lang-fr

--- a/acceptance/functions/FunctionsGlobal.robot
+++ b/acceptance/functions/FunctionsGlobal.robot
@@ -73,3 +73,18 @@ Page ShouldShow Footer
   Click Element                  ${BTN_FLAG_FR}
   Location Should Be             ${GK_URL}
 
+## V2
+!Click On EN Lang
+  Wait Until Element Is Visible  ${DROPDOWN_LANG}
+  Click Element                  ${DROPDOWN_LANG}
+  Wait Until Element Is Visible  ${DROPDOWN_LANG_EN}
+  Click Element                  ${DROPDOWN_LANG_EN}
+  Location Should Be             ${GK_URL}en?
+
+!Click On FR Lang
+  Wait Until Element Is Visible  ${DROPDOWN_LANG}
+  Click Element                  ${DROPDOWN_LANG}
+  Wait Until Element Is Visible  ${DROPDOWN_LANG_FR}
+  Click Element                  ${DROPDOWN_LANG_FR}
+  Location Should Be             ${GK_URL}fr?
+

--- a/acceptance/vars/robot-vars.py
+++ b/acceptance/vars/robot-vars.py
@@ -10,3 +10,5 @@ GK_URL_RUCHY = GK_URL + "ruchy.php"
 
 TEST_GEOKRET_REF = "GK10BCD"
 TEST_GEOKRET_CODE = "673CI2"
+
+print(" starting robot test - target {}".format(GK_URL))


### PR DESCRIPTION
Fix #52 new-them qa compatibility
- new-theme first QA tests for en/fr home page under `acceptance/TestGeokretyV2/`
- keep legacy acceptance tests
- add env related tests version
- rework Makefile